### PR TITLE
feat(sensor): Add raw RGB channel extraction block for APDS9960 color sensor

### DIFF
--- a/_locales/zh-CN/pxt-PlanetX-strings.json
+++ b/_locales/zh-CN/pxt-PlanetX-strings.json
@@ -1,6 +1,7 @@
 {
     "PlanetX_Basic.AnalogRJPin.J1|block": "J1",
     "PlanetX_Basic.AnalogRJPin.J2|block": "J2",
+    "PlanetX_Basic.apds9960_extract_rgb|block": "颜色传感器 IIC端口 获取 $channel 原始值",
     "PlanetX_Basic.BME280_state.BME280_altitude|block": "海拔(M)",
     "PlanetX_Basic.BME280_state.BME280_humidity|block": "湿度(0~100%)",
     "PlanetX_Basic.BME280_state.BME280_pressure|block": "气压(hPa)",
@@ -104,7 +105,6 @@
     "PlanetX_Basic.buttonCD|block": "按钮模块 %Rjpin 按键 %button 被按下",
     "PlanetX_Basic.buttonEvent|block": "当按钮 %Rjpin %button 被按下时",
     "PlanetX_Basic.checkCard|block": "RFID 传感器 IIC接口 检测到卡片",
-    "PlanetX_Basic.apds9960_extract_rgb|block": "颜色传感器 IIC端口 获取 $channel 值"
     "PlanetX_Basic.checkColor|block": "颜色识别传感器 IIC接口 检测到 %color",
     "PlanetX_Basic.dht11Sensor|block": "DHT11 温湿度传感器 %Rjpin %dht11state 值",
     "PlanetX_Basic.dht20Sensor|block": "DHT20 温湿度传感器 %dht20state 值",

--- a/_locales/zh-CN/pxt-PlanetX-strings.json
+++ b/_locales/zh-CN/pxt-PlanetX-strings.json
@@ -104,6 +104,7 @@
     "PlanetX_Basic.buttonCD|block": "按钮模块 %Rjpin 按键 %button 被按下",
     "PlanetX_Basic.buttonEvent|block": "当按钮 %Rjpin %button 被按下时",
     "PlanetX_Basic.checkCard|block": "RFID 传感器 IIC接口 检测到卡片",
+    "PlanetX_Basic.apds9960_extract_rgb|block": "颜色传感器 IIC端口 获取 $channel 值"
     "PlanetX_Basic.checkColor|block": "颜色识别传感器 IIC接口 检测到 %color",
     "PlanetX_Basic.dht11Sensor|block": "DHT11 温湿度传感器 %Rjpin %dht11state 值",
     "PlanetX_Basic.dht20Sensor|block": "DHT20 温湿度传感器 %dht20state 值",

--- a/basic.ts
+++ b/basic.ts
@@ -1,3 +1,12 @@
+/*
+Create global variables to hold the red, green and blue value generated in readColor() 
+*/
+namespace planetX_RGB_cache {
+    export let r = 0;
+    export let g = 0;
+    export let b = 0;
+}
+
 /**
 * Functions to PlanetX sensor by ELECFREAKS Co.,Ltd.
 */
@@ -1240,6 +1249,16 @@ namespace PlanetX_Basic {
         white
     }
 
+    // Block for reading red, green and blue values
+    export enum RGBChannel {
+        //% block="Red"
+        Red = 1,
+        //% block="Green"
+        Green = 2,
+        //% block="Blue"
+        Blue = 3,
+    }
+
     export enum GasList {
         //% block="Co"
         Co,
@@ -2169,6 +2188,12 @@ namespace PlanetX_Basic {
         r = r * 255 / avg;
         g = g * 255 / avg;
         b = b * 255 / avg;
+
+        // Cache the rgb values
+        planetX_RGB_cache.r = r;
+        planetX_RGB_cache.g = g;
+        planetX_RGB_cache.b = b;
+        
         //let hue = rgb2hue(r, g, b);
         let hue = rgb2hsl(r, g, b)
         if (color_new_init == true && hue >= 180 && hue <= 201 && temp_c >= 6000 && (temp_b - temp_g) < 1000 || (temp_r > 4096 && temp_g > 4096 && temp_b > 4096)) {
@@ -2177,6 +2202,7 @@ namespace PlanetX_Basic {
         }
         return hue
     }
+    
     //% block="Color sensor IIC port detects %color"
     //% subcategory=Sensor group="IIC Port"
     //% color.fieldEditor="gridpicker" color.fieldOptions.columns=3
@@ -2242,6 +2268,22 @@ namespace PlanetX_Basic {
         }
     }
 
+    //% blockId=apds9960_extract_rgb block="Color sensor IIC port get $channel value (0~255)"
+    //% subcategory=Sensor group="IIC Port"
+    //% channel.defl=RGBChannel.Red
+    export function extractRGB(channel: RGBChannel): number {
+        switch (channel) {
+            case RGBChannel.Red:
+                return Math.round(planetX_RGB_cache.r);
+            case RGBChannel.Green:
+                return Math.round(planetX_RGB_cache.g);
+            case RGBChannel.Blue:
+                return Math.round(planetX_RGB_cache.b);
+            default:
+                return 0;
+        }
+    }
+    
     //% block="RFID sensor IIC port read data from card"
     //% subcategory=Sensor group="IIC Port"
     export function readDataBlock(): string {

--- a/basic.ts
+++ b/basic.ts
@@ -2177,18 +2177,18 @@ namespace PlanetX_Basic {
         serial.writeLine("b")
         serial.writeNumber(c)
         serial.writeLine("c")
-
+        
+        // Cache the rgb values
+        cachedRed = r;
+        cachedGreen = g;
+        cachedBlue = b;
+        
         // map to rgb based on clear channel
         let avg = c / 3;
         r = r * 255 / avg;
         g = g * 255 / avg;
         b = b * 255 / avg;
 
-        // Cache the rgb values
-        cachedRed = r;
-        cachedGreen = g;
-        cachedBlue = b;
-        
         //let hue = rgb2hue(r, g, b);
         let hue = rgb2hsl(r, g, b)
         if (color_new_init == true && hue >= 180 && hue <= 201 && temp_c >= 6000 && (temp_b - temp_g) < 1000 || (temp_r > 4096 && temp_g > 4096 && temp_b > 4096)) {

--- a/basic.ts
+++ b/basic.ts
@@ -2263,7 +2263,7 @@ namespace PlanetX_Basic {
         }
     }
 
-    //% blockId=apds9960_extract_rgb block="Color sensor IIC port get $channel value (0~255)"
+    //% blockId=apds9960_extract_rgb block="Color sensor IIC port get raw $channel value"
     //% subcategory=Sensor group="IIC Port"
     //% channel.defl=RGBChannel.Red
     export function extractRGB(channel: RGBChannel): number {

--- a/basic.ts
+++ b/basic.ts
@@ -1,12 +1,3 @@
-/*
-Create global variables to hold the red, green and blue value generated in readColor() 
-*/
-namespace planetX_RGB_cache {
-    export let r = 0;
-    export let g = 0;
-    export let b = 0;
-}
-
 /**
 * Functions to PlanetX sensor by ELECFREAKS Co.,Ltd.
 */
@@ -187,6 +178,10 @@ namespace PlanetX_Basic {
     const APDS9960_AICLEAR = 0xE7
     let color_first_init = false
     let color_new_init = false
+    
+    let cachedRed = 0
+    let cachedGreen = 0
+    let cachedBlue = 0
 
     let __dht11_last_read_time = 0;
     let __temperature: number = 0
@@ -2190,9 +2185,9 @@ namespace PlanetX_Basic {
         b = b * 255 / avg;
 
         // Cache the rgb values
-        planetX_RGB_cache.r = r;
-        planetX_RGB_cache.g = g;
-        planetX_RGB_cache.b = b;
+        cachedRed = r;
+        cachedGreen = g;
+        cachedBlue = b;
         
         //let hue = rgb2hue(r, g, b);
         let hue = rgb2hsl(r, g, b)
@@ -2274,11 +2269,11 @@ namespace PlanetX_Basic {
     export function extractRGB(channel: RGBChannel): number {
         switch (channel) {
             case RGBChannel.Red:
-                return Math.round(planetX_RGB_cache.r);
+                return Math.round(cachedRed);
             case RGBChannel.Green:
-                return Math.round(planetX_RGB_cache.g);
+                return Math.round(cachedGreen);
             case RGBChannel.Blue:
-                return Math.round(planetX_RGB_cache.b);
+                return Math.round(cachedBlue);
             default:
                 return 0;
         }


### PR DESCRIPTION
### Description
This pull request introduces a new custom reporter block (`extractRGB`) for the APDS9960 I2C color sensor. 

Currently, the extension reads raw hardware RGB registers to calculate the `HUE` value, but it does not expose the individual Red, Green, and Blue values directly to the user as draggable blocks. This addition allows students and advanced users to extract the true, raw light intensity data for specific color channels directly into their logic and math blocks.

### Changes Made
* **`basic.ts`**:
  * Added an `RGBChannel` enum inside `namespace PlanetX_Basic` to handle the user dropdown selection (Red, Green, Blue).
  * Added hidden namespace-level variables (`cachedRed`, `cachedGreen`, `cachedBlue`) to securely hold data snapshots.
  * Updated the `readColor()` function to cache the unmutated raw hardware variables immediately after reading them and before the internal Hue conversion math alters them.
  * Created the public `extractRGB` reporter block function under the **IIC Port** group.
* **`_locales/zh-CN/pxt-PlanetX-strings.json`**:
  * Added the mandatory localized translation string for the new block ID (`PlanetX_Basic.apds9960_extract_rgb|block`).

### Testing Done
Verified block functionality inside the Microsoft MakeCode micro:bit workspace by targeting this fork. The new block correctly appears in the toolbox, fits seamlessly into logic wrappers, and its channel data matches up directly with physical sensor readouts verified on the live serial monitor.
